### PR TITLE
Fix comment in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
-yntax Coloring Map For Audio
+# Syntax Coloring Map For Brief
 #######################################
 
 #######################################


### PR DESCRIPTION
The first line of the file was intended to be a comment but the first few characters were somehow lost. This caused that line to be interpreted as a malformed keyword definition.

The library name in the comment was incorrectly stated as "Audio" rather than the true name of this library: "Brief".