### PR TITLE
Use correct and valid KEYWORD_TOKENTYPEs in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,19 +12,19 @@ Brief	KEYWORD1
 #######################################
 
 setup	KEYWORD2
-loop	KEYWORD3
-memget	KEYWORD4
-memset	KEYWORD5
-bind	KEYWORD6
-push	KEYWORD7
-pop	KEYWORD8
-error	KEYWORD9
-exec	KEYWORD10
+loop	KEYWORD2
+memget	KEYWORD2
+memset	KEYWORD2
+bind	KEYWORD2
+push	KEYWORD2
+pop	KEYWORD2
+error	KEYWORD2
+exec	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-MEM_SIZE	KEYWORD11
-DATA_STACK_SIZE	KEYWORD12
-RETURN_STACK_SIZE	KEYWORD13
+MEM_SIZE	LITERAL1
+DATA_STACK_SIZE	LITERAL1
+RETURN_STACK_SIZE	LITERAL1


### PR DESCRIPTION
Use of an invalid KEYWORD_TOKENTYPE value in keywords.txt causes the keyword to be highlighted by the default editor.function.style theme setting (as used by KEYWORD2, KEYWORD3, LITERAL2) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older, the undocumented KEYWORD4 causes the keyword to use the theme style used for operators, KEYWORD5 causes the keyword to use the theme style for hyperlinks, KEYWORD6 uses editor.invalid.style, KEYWORD7-9 causes the IDE to glitch out.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype