### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=A scriptable firmware and protocol for interfacing hardware.
 paragraph=It is comprised of a VM – a tiny stack machine running on the MCU, Protocol – an extensible and composable set of commands and events, Language – a Forth-like interactive scripting language compiled for the VM, Interactive – console for interactive experimentation and development.
 category=Other
 url=https://github.com/AshleyF/BriefEmbedded
-architecture=*
+architectures=*
 includes=Brief.h


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format