### PR TITLE
Remove #include directive for unused Servo.h

### DIFF
--- a/src/Brief.h
+++ b/src/Brief.h
@@ -5,7 +5,6 @@
 
 #define __STDC_LIMIT_MACROS
 #include <Arduino.h>
-#include <Servo.h>
 #include <Wire.h>
 
 #ifndef BRIEF_H


### PR DESCRIPTION
Servo support was removed in https://github.com/AshleyF/BriefEmbedded/commit/8e49a56d6ae7df334c21a3192b20470b9b50309c so this is no longer needed.